### PR TITLE
Update check for cli to not throw an error

### DIFF
--- a/Create-PHP-YASnippet.php
+++ b/Create-PHP-YASnippet.php
@@ -49,7 +49,7 @@ define("ERROR_UNKNOWN_METHOD", 4);
  * who knows.  Better to lock this up as tightly as possible than to
  * find out later that it creates an obscure security hole.
  */
-if (PHP_SAPI !== "cli" || $_SERVER["SERVER_NAME"] !== NULL)
+if (PHP_SAPI !== "cli" || isset($_SERVER["SERVER_NAME"]))
 {
         exit(ERROR_NOT_CLI);
 }


### PR DESCRIPTION
Thanks for the great plugin! This is just what I needed.

I ran the php script from the command line outside of emacs and got the error

```
Notice: Undefined index: SERVER_NAME
```

On my system $_SERVER["SERVER_NAME"] is not defined when running php from the command line, so I changed the conditional to an isset to account for that.
