### PR TITLE
Create php-mode snippet table when not exist

### DIFF
--- a/php-auto-yasnippets.el
+++ b/php-auto-yasnippets.el
@@ -173,6 +173,8 @@ signals an error."
 The INPUT must be the name of a PHP standard library function.
 This function creates a snippet for that function and associates
 it with `php-mode'."
+  (unless (gethash 'php-mode yas--tables)
+    (yas--table-get-create 'php-mode))
   (unless (yas--get-template-by-uuid 'php-mode input)
     (with-temp-buffer
       (let ((exit-code (payas/create-template input)))


### PR DESCRIPTION
if there is no php-mode snippet table, yas/create-php-snippet don't work
and display a message that says "or: yas--table-uuidhash accessing a
non-yas--table".
