### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/php-auto-yasnippets.el
+++ b/php-auto-yasnippets.el
@@ -5,6 +5,7 @@
 ;; Author: Eric James Michael Ritz
 ;; URL: https://github.com/ejmr/php-auto-yasnippets
 ;; Version: 1.1.0
+;; Package-Requires: ((php-mode "1.11") (yasnippet "0.8.0"))
 ;;
 ;;
 ;;


### PR DESCRIPTION
When installed as a package from an ELPA archive such as [Marmalade](http://marmalade-repo.org/) or
[MELPA](http://melpa.milkbox.net/), this header tells package.el to also install php-mode and yasnippet, which the library requires.
