### PR TITLE
Add autoload cookie to yas/create-php-snippet

### DIFF
--- a/php-auto-yasnippets.el
+++ b/php-auto-yasnippets.el
@@ -211,6 +211,7 @@ cleans up that whitespace so that the PHP code looks better."
 
 ;;; This section contains the public API.
 
+;;;###autoload
 (defun yas/create-php-snippet (prefix)
   "Creates and expands a snippet for the PHP function at point.
 


### PR DESCRIPTION
The autoload cookie is necessary so we can run yas/create-php-snippet without an explicit require.
