### PR TITLE
Always use php-mode's ac-dict for auto-completion

### DIFF
--- a/php-auto-yasnippets.el
+++ b/php-auto-yasnippets.el
@@ -135,7 +135,7 @@ It's probably best to set this per-project via .dir-locals.")
        '((depends yasnippet)
          ;; TODO The php-mode dictionary contains a few things (keywords and
          ;; the like) that should not be included
-         (candidates . ac-buffer-dictionary)
+         (candidates . (ac-mode-dictionary 'php-mode))
          (action . payas/ac-insert-func-and-create-snippet)
 
          ;; Since these trigger yasnippet, use the yasnippet face.


### PR DESCRIPTION
This makes it easier to use this ac-source in modes other than php-mode,
which can be handy when writing PHP-based templates in something like [web-mode](http://web-mode.org/).
